### PR TITLE
feat: embed reply-to context in compiled todos

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -311,7 +311,7 @@ pub async fn run(settings: Arc<LiveSettings>) -> Result<()> {
 }
 /// Format a message append with message ID and sender info
 pub fn format_message_append_with_sender(message: &str, last_write_datetime: Option<Timestamp>, now: Timestamp, msg_id: Option<i32>, sender: Option<&str>) -> String {
-	format_message_append(message, last_write_datetime, now, msg_id, sender, false)
+	format_message_append(message, last_write_datetime, now, msg_id, sender, false, None)
 }
 /// Send a message via MTProto, handling image extraction
 /// Returns the message ID assigned by Telegram
@@ -331,13 +331,14 @@ async fn send_message_mtproto(client: &Client, message: &Message) -> Result<i32>
 	crate::mtproto::send_text_message(client, message.group_id, message.topic_id, &message.message).await
 }
 
-pub(crate) fn format_message_append(message: &str, last_write_datetime: Option<Timestamp>, now: Timestamp, msg_id: Option<i32>, sender: Option<&str>, forwarded: bool) -> String {
+pub(crate) fn format_message_append(message: &str, last_write_datetime: Option<Timestamp>, now: Timestamp, msg_id: Option<i32>, sender: Option<&str>, forwarded: bool, reply_to_msg_id: Option<i32>) -> String {
 	debug!("Formatting message append");
 
 	let fwd_prefix = if forwarded { "forwarded " } else { "" };
+	let reply_part = reply_to_msg_id.map(|id| format!(" reply_to:{id}")).unwrap_or_default();
 	let id_suffix = match (msg_id, sender) {
-		(Some(id), Some(s)) => format!(" <!-- {fwd_prefix}msg:{id} {s} -->"),
-		(Some(id), None) => format!(" <!-- {fwd_prefix}msg:{id} -->"),
+		(Some(id), Some(s)) => format!(" <!-- {fwd_prefix}msg:{id}{reply_part} {s} -->"),
+		(Some(id), None) => format!(" <!-- {fwd_prefix}msg:{id}{reply_part} -->"),
 		_ => String::new(),
 	};
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1067,6 +1067,28 @@ that should be combined
 	}
 
 	#[test]
+	fn parse_file_messages_reply_to() {
+		let content = "check this out <!-- msg:100 reply_to:99 user -->\noriginal message <!-- msg:99 user -->\n";
+		let messages = parse_file_messages(content);
+		insta::assert_debug_snapshot!(messages, @r#"
+		{
+		    99: ParsedMessage {
+		        content: "original message",
+		        is_voice: false,
+		        reply_to_msg_id: None,
+		    },
+		    100: ParsedMessage {
+		        content: "check this out",
+		        is_voice: false,
+		        reply_to_msg_id: Some(
+		            99,
+		        ),
+		    },
+		}
+		"#);
+	}
+
+	#[test]
 	fn test_coalesce_new_messages() {
 		let lines = vec![
 			"First message".to_string(),


### PR DESCRIPTION
## Summary
- When a TODO message is a reply to another message, the compiled `todos.md` now includes the replied-to content as a blockquote beneath the TODO line, providing context for TODOs that would otherwise appear cut off
- Adds `reply_to:ID` qualifier to message tags (`<!-- msg:123 reply_to:456 user -->`) so reply relationships are preserved in local files
- Gracefully degrades: existing messages without `reply_to` tags simply get no blockquote; voice replies show `[voice]`; missing messages show `<msg_id>`

## Example output
```markdown
- [ ] TODO: add to knowledgebase (Feb 21) <!-- todo:2244305221:1:3379 -->
  > The article about distributed caching patterns was really useful
```

## Test plan
- [x] All 60 existing tests pass
- [x] Clippy clean (pre-existing errors.rs warnings only)
- [ ] Manual test with real Telegram data: pull messages with replies, run `tg todos compile`, verify blockquotes appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)